### PR TITLE
fix memory leak in gaussian integral C extension

### DIFF
--- a/c/integrals.c
+++ b/c/integrals.c
@@ -318,6 +318,7 @@ static PyObject* GaussianIntegral(PyObject* self, PyObject *arg, PyObject *keywo
 
     // Free python memory
     Py_DECREF(polyCoeffArray);
+    Py_DECREF(centerArray);
 
     return Py_BuildValue("d", integral * pre_exponential);
 }
@@ -439,6 +440,7 @@ static PyObject* GaussianIntegral2(PyObject* self, PyObject *arg, PyObject *keyw
 
     // Free python memory
     Py_DECREF(polyCoeffArray);
+    Py_DECREF(centerArray);
     free(expList);
     free(preExpList);
 


### PR DESCRIPTION
Hi Abel,

I finally had some time to go looking for the memory leak, and I found it.

Best,
Emmanuel

---

Fixes the memory leak reported in #11.

Both `GaussianIntegral` and `GaussianIntegral2` in `c/integrals.c` obtain a PyObject reference for the `center` argument via `PyArray_FROM_OTF` but never decrement it. As a result, each invocation leaks one reference to the center array.

Because `gaussian_integral_2` is invoked once for every primitive Gaussian in every overlap evaluation (self-overlap plus once per symmetry operation per orbital), these leaks accumulate quickly, leading to out-of-memory failures on large systems such as C100 fullertube. Below is the memory footprint before and after:

**Before:**
<img width="1472" height="382" alt="mem_leak_1" src="https://github.com/user-attachments/assets/186ebf1b-6020-4256-8d54-90a550b01db4" />

**After:**
<img width="1472" height="382" alt="mem_leak_2" src="https://github.com/user-attachments/assets/17b2779a-15b4-40d6-8a46-767f48201171" />

The fix adds the missing `Py_DECREF(centerArray)` in both functions, matching the existing pattern used for `polyCoeffArray`.